### PR TITLE
Kusto

### DIFF
--- a/containererrorlogs
+++ b/containererrorlogs
@@ -1,0 +1,4 @@
+ContainerLog
+| where LogEntry contains "error" or LogEntry contains "fail"
+| project TimeGenerated, LogEntry, ContainerID, Image, Name
+| order by TimeGenerated desc

--- a/nodecpu
+++ b/nodecpu
@@ -1,0 +1,5 @@
+Perf
+| where ObjectName == "K8SNode" and CounterName == "cpuUsageNanoCores"
+| extend CPUPercent = CounterValue / 10000000
+| summarize AvgCPU = avg(CPUPercent) by bin(TimeGenerated, 1h), Computer
+| order by TimeGenerated desc

--- a/restartcount
+++ b/restartcount
@@ -1,0 +1,4 @@
+KubePodInventory
+| where ContainerRestartCount > 0
+| summarize TotalRestarts = sum(ContainerRestartCount) by bin(TimeGenerated, 1h), Name
+| order by TimeGenerated desc


### PR DESCRIPTION
group container error results by the specific fields:


ContainerLog
| where LogLevel == "error"
| summarize ErrorCount = count() by ContainerName, PodName, Namespace, bin(TimeGenerated, 10m)
| order by ErrorCount desc
